### PR TITLE
Make the pink terminal colour also bold, just like the others.

### DIFF
--- a/langchain/input.py
+++ b/langchain/input.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 _TEXT_COLOR_MAPPING = {
     "blue": "36;1",
     "yellow": "33;1",
-    "pink": "38;5;200",
+    "pink": "38;5;200;1",
     "green": "32;1",
     "red": "31;1",
 }


### PR DESCRIPTION
# Make the pink terminal colour also bold, just like the others.

All the other terminal colours are bold, but this one wasn't. Tested on OSX Terminal, and indeed the extended colours are not bolded by default.

Someone on Discord asked how to change the colours, so I read the source code, and discovered this inconsistency.

<!-- Remove if not applicable -->
<!-- If you're adding a new integration, include an integration test and an example notebook showing its use! -->

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoaders
        - @eyurtsev

        Models
        - @hwchase17
        - @agola11

        Agents / Tools / Toolkits
        - @vowelparrot
        
        VectorStores / Retrievers / Memory
        - @dev2049
        
 -->
